### PR TITLE
Update nxosmac variable name

### DIFF
--- a/MacToIpMapper.py
+++ b/MacToIpMapper.py
@@ -53,7 +53,7 @@ uplink=values[3]
 #Commands
 catosmac='show mac address-table dynamic'
 catosarp='show ip arp'
-nxsmac=''
+nxosmac=''
 nxsarp='show ip arp'
 aristamac=''
 aristaarp=''


### PR DESCRIPTION
## Summary
- rename `nxsmac` to `nxosmac` in `MacToIpMapper.py`

## Testing
- `python3 -m py_compile MacToIpMapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68464c1afbd083219599cca3995a3f3b