### PR TITLE
Fix OS detection failure exit

### DIFF
--- a/MacToIpMapper.py
+++ b/MacToIpMapper.py
@@ -14,9 +14,9 @@ def check_os(IP,username, password):
 
     guesser = SSHDetect(**remote_device)
     best_match = guesser.autodetect()
-    if best_match is None:
+    if not best_match:
         print('Could not detect OS, please check IP or Device')
-        raise ValueError(f"Unable to detect OS for device {IP}")
+        quit()
 
     #print(f'IP:{IP} OS is {best_match}')
     return best_match


### PR DESCRIPTION
## Summary
- treat empty OS detection results as failure
- exit script with `quit()` if OS detection fails

## Testing
- `python -m py_compile MacToIpMapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68464c1ec5948321baac09ca1e156223